### PR TITLE
Fix import error causing bot crash

### DIFF
--- a/src/bot/gem_research_handler.py
+++ b/src/bot/gem_research_handler.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Optional, Tuple
 from dataclasses import dataclass
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
-from api.geckoterminal_client import TokenData
+from src.api.geckoterminal_client import TokenData
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
- Change from api.geckoterminal_client to src.api.geckoterminal_client
- Resolves ModuleNotFoundError in production environment